### PR TITLE
Smoothing weights should be inverse stdev

### DIFF
--- a/R/bumphunter.R
+++ b/R/bumphunter.R
@@ -98,7 +98,7 @@ bumphunterEngine<-function(mat, design, chr = NULL, pos,
         tmp <- .getEstimate(mat = mat, design = design,
                             coef = coef, full = TRUE)
         rawBeta <- tmp$coef
-        weights <- tmp$sigma
+        weights <- 1/tmp$sigma
         rm(tmp)
     } else {
         rawBeta <- .getEstimate(mat = mat, design = design, coef = coef,


### PR DESCRIPTION
The weights provided to the smoothing function should be the inverse standard deviation of the methylation difference coefficient, since we want to place more weight on observations with less variation.