### PR TITLE
v1.17.2 -- Adds supported for TxDb objects with gene ids from ENSEMBL/GENCODE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: bumphunter
-Version: 1.17.1
+Version: 1.17.2
 Title: Bump Hunter
 Description: Tools for finding bumps in genomic data
 Authors@R: c(person(c("Rafael", "A."), "Irizarry", role = c("cre","aut"), email

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -24,6 +24,7 @@ importFrom(utils, data, packageDescription)
 importFrom(parallel, mclapply, stopCluster)
 importFrom(GenomicFeatures, exonsBy, cdsBy, transcriptsBy)
 importFrom(AnnotationDbi, mappedkeys)
+importMethodsFrom(AnnotationDbi, mapIds)
 
 export(bumphunter, bumphunterEngine, clusterMaker, boundedClusterMaker,
        dummyData, getSegments, 

--- a/man/annotateTranscripts.Rd
+++ b/man/annotateTranscripts.Rd
@@ -7,7 +7,7 @@ Annotate transcripts
 Annotate transcripts
 }
 \usage{
-annotateTranscripts(txdb, annotationPackage = NULL, by = c("tx","gene"), codingOnly=FALSE, verbose = TRUE, requireAnnotation = FALSE)
+annotateTranscripts(txdb, annotationPackage = NULL, by = c("tx","gene"), codingOnly=FALSE, verbose = TRUE, requireAnnotation = FALSE, mappingInfo = NULL, simplifyGeneID = FALSE)
 }
 \arguments{
   \item{txdb}{
@@ -34,6 +34,17 @@ annotateTranscripts(txdb, annotationPackage = NULL, by = c("tx","gene"), codingO
     logical value. If 'TRUE' function will stop if no annotation package
     is successfully loaded.
   }
+  \item{mappingInfo}{
+    a named list with elements 'column', 'keytype' and 'multiVals'. If specified
+    this information will be used with \link[AnnotationDbi]{mapIds} when mapping
+    the gene ids using \code{annotationPackage}. This is useful when working
+    with a \code{txdb} object from ENSEMBL or GENCODE among other databases.
+  }
+  \item{simplifyGeneID}{
+    logical value. If 'TRUE', gene ids will be shortened to before a dot is
+    present in the id. This is useful for changing GENCODE gene ids to
+    ENSEMBL ids.
+  }
 }
 \details{
   This function prepares a \code{GRanges} for the \code{\link{matchGenes}}
@@ -51,7 +62,8 @@ annotateTranscripts(txdb, annotationPackage = NULL, by = c("tx","gene"), codingO
   number of exons, \code{Exons} is an \code{IRanges} with the exon information.
 }
 \author{
-  Harris Jaffee and Rafael A. Irizarry
+  Harris Jaffee and Rafael A. Irizarry.
+  'mappingInfo' and 'simplifyGeneID' contributed by Leonardo Collado-Torres.
 }
 
 \seealso{


### PR DESCRIPTION
This commit resolves https://github.com/rafalab/bumphunter/issues/15 by
adding the arguments `mappingInfo` and `simplifyGeneID` to
`annotateTranscripts()`. `mappingInfo` is a named list whose elements are passed
to `AnnotateDbi::mapIds()` for more flexible gene id matching between a given
TxDb object and the organism package (like org.Hs.eg.db). `simplifyGeneId` is
a logical and if TRUE gene ids like `ENSTsomething.8_etc` get simplified to
`ENSTsomething`. This allows working with TxDb objects created from
GENCODE GTF files and matching then to org.Hs.eg.db as if the ids were
ENSEMBL gene ids.

A unit test checking the new changes has been added as well.

A check and build reveals no new notes/warnings/errors.

```
$ R CMD build --keep-empty-dirs --no-resave-data bumphunter
Loading required package: colorout
* checking for file ‘bumphunter/DESCRIPTION’ ... OK
* preparing ‘bumphunter’:
* checking DESCRIPTION meta-information ... OK
* installing the package to build vignettes
* creating vignettes ... OK
* checking for LF line-endings in source and make files
* checking for empty or unneeded directories
* looking to see if a ‘data/datalist’ file should be added
* building ‘bumphunter_1.17.2.tar.gz’

$ R CMD check --no-vignettes --timings bumphunter_1.17.2.tar.gz
Loading required package: colorout
* using log directory ‘/Users/lcollado/Dropbox/Code/bumphunter.Rcheck’
* using R version 3.4.0 (2017-04-21)
* using platform: x86_64-apple-darwin15.6.0 (64-bit)
* using session charset: UTF-8
* using option ‘--no-vignettes’
* checking for file ‘bumphunter/DESCRIPTION’ ... OK
* this is package ‘bumphunter’ version ‘1.17.2’
* checking package namespace information ... OK
* checking package dependencies ... NOTE
Depends: includes the non-default packages:
  ‘S4Vectors’ ‘IRanges’ ‘GenomeInfoDb’ ‘GenomicRanges’ ‘foreach’
  ‘iterators’ ‘parallel’ ‘locfit’
Adding so many packages to the search path is excessive and importing
selectively is preferable.
* checking if this is a source package ... OK
* checking if there is a namespace ... OK
* checking for executable files ... OK
* checking for hidden files and directories ... OK
* checking for portable file names ... OK
* checking for sufficient/correct file permissions ... OK
* checking whether package ‘bumphunter’ can be installed ... OK
* checking installed package size ... OK
* checking package directory ... OK
* checking ‘build’ directory ... OK
* checking DESCRIPTION meta-information ... NOTE
Malformed Description field: should contain one or more complete sentences.
* checking top-level files ... OK
* checking for left-over files ... OK
* checking index information ... OK
* checking package subdirectories ... OK
* checking R files for non-ASCII characters ... OK
* checking R files for syntax errors ... OK
* checking whether the package can be loaded ... OK
* checking whether the package can be loaded with stated dependencies ... OK
* checking whether the package can be unloaded cleanly ... OK
* checking whether the namespace can be loaded with stated dependencies ... OK
* checking whether the namespace can be unloaded cleanly ... OK
* checking dependencies in R code ... NOTE
Unexported object imported by a ':::' call: ‘doParallel:::.options’
  See the note in ?`:::` about the use of this operator.
* checking S3 generic/method consistency ... OK
* checking replacement functions ... OK
* checking foreign function calls ... OK
* checking R code for possible problems ... NOTE
bumphunterEngine: no visible binding for global variable ‘bootstraps’
Undefined global functions or variables:
  bootstraps
* checking Rd files ... OK
* checking Rd metadata ... OK
* checking Rd cross-references ... OK
* checking for missing documentation entries ... OK
* checking for code/documentation mismatches ... OK
* checking Rd \usage sections ... OK
* checking Rd contents ... OK
* checking for unstated dependencies in examples ... OK
* checking contents of ‘data’ directory ... OK
* checking data for non-ASCII characters ... OK
* checking data for ASCII and uncompressed saves ... OK
* checking sizes of PDF files under ‘inst/doc’ ... OK
* checking installed files from ‘inst/doc’ ... OK
* checking files in ‘vignettes’ ... OK
* checking examples ... OK
* checking for unstated dependencies in ‘tests’ ... OK
* checking tests ...
  Running ‘runTests.R’
  Running ‘test-all.R’
 OK
* checking for unstated dependencies in vignettes ... OK
* checking package vignettes in ‘inst/doc’ ... OK
* checking running R code from vignettes ... SKIPPED
* checking re-building of vignette outputs ... SKIPPED
* checking PDF version of manual ... OK
* DONE

Status: 4 NOTEs
See
  ‘/Users/lcollado/Dropbox/Code/bumphunter.Rcheck/00check.log’
for details.

```