### PR TITLE
Bugfix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: bumphunter
-Version: 1.17.2
+Version: 1.17.3
 Title: Bump Hunter
 Description: Tools for finding bumps in genomic data
 Authors@R: c(person(c("Rafael", "A."), "Irizarry", role = c("cre","aut"), email
@@ -38,3 +38,4 @@ LazyData: yes
 URL: https://github.com/ririzarr/bumphunter
 biocViews: DNAMethylation, Epigenetics, Infrastructure,
     MultipleComparison
+RoxygenNote: 6.0.1

--- a/R/bumphunter.R
+++ b/R/bumphunter.R
@@ -224,7 +224,7 @@ bumphunterEngine<-function(mat, design, chr = NULL, pos,
     chunksize <- ceiling(B/workers)
     subMat <- NULL
     nulltabs <- foreach(subMat = iter(permBeta, by = "col", chunksize = chunksize),
-        .combine = "c", .packages = "bumphunter", .verbose=TRUE) %dorng% {
+        .combine = "c", .packages = "bumphunter") %dorng% {
         apply(subMat, 2, regionFinder, chr = chr, pos = pos,
             cluster = cluster, cutoff = cutoff, ind = Index,
             verbose = FALSE)

--- a/R/bumphunter.R
+++ b/R/bumphunter.R
@@ -224,7 +224,7 @@ bumphunterEngine<-function(mat, design, chr = NULL, pos,
     chunksize <- ceiling(B/workers)
     subMat <- NULL
     nulltabs <- foreach(subMat = iter(permBeta, by = "col", chunksize = chunksize),
-        .combine = "c", .packages = "bumphunter") %dorng% {
+        .combine = "c", .packages = "bumphunter", .verbose=TRUE) %dorng% {
         apply(subMat, 2, regionFinder, chr = chr, pos = pos,
             cluster = cluster, cutoff = cutoff, ind = Index,
             verbose = FALSE)


### PR DESCRIPTION
This is the bug fix recommended by Hervé Pagès for a bug created by an update to the GenomicRanges and IRanges classes. GenomicRanges::nearest has been modified to improve internal consistency of Bioconductor classes. 

Previously, GenomicRanges::nearest did not find all subject ranges at a distance of zero from a query range. It found overlapped ranges but not adjacent ranges. Now it finds both and if parameter select is not set to "all," it picks one randomly. matchGenes needs it to return the zero-distance range of maximum overlap if there is one.

GenomicRanges::nearest has been wrapped in a function called smarterNearest which checks all equally distant nearest ranges and chooses the one of maximum overlap. 